### PR TITLE
Update 03_cv_oly.stringtable

### DIFF
--- a/data/localized/fr-fixed/text/conversations/03_defiance_bay_ondra_gift/03_cv_oly.stringtable
+++ b/data/localized/fr-fixed/text/conversations/03_defiance_bay_ondra_gift/03_cv_oly.stringtable
@@ -171,7 +171,7 @@
     </Entry>
     <Entry>
       <ID>48</ID>
-      <DefaultText>"Peu importe, je me souviens de cette soirée parce qu'il disait que les choses allaient enfin changer. Il allait trouver un boulot fixe, se ranger, embrasser une vie respectable. Je lui ai dit que dans ce cas, il pouvait nous payer à boire." Il touche le bord de son godet. "C'est quand on s'est pointés."</DefaultText>
+      <DefaultText>"Peu importe, je me souviens de cette soirée parce qu'il disait que les choses allaient enfin changer. Il allait trouver un boulot fixe, se ranger, embrasser une vie respectable. Je lui ai dit que dans ce cas, il pouvait nous payer à boire." Il touche le bord de son godet. "C'est quand elle s'est pointée."</DefaultText>
       <FemaleText />
     </Entry>
     <Entry>


### PR DESCRIPTION
Corrigé à partir de la version anglaise. :

<Entry>
      <ID>48</ID>
      <DefaultText>"Anyway, I remember that night because he said things were finally turning around. He was going to find a steady job, clean up, have another crack at the respectable life. I told him in that case, he could buy the drinks." He traces the rim of his cup. "That's when she showed up."</DefaultText>
      <FemaleText />
    </Entry>
